### PR TITLE
Bugfix setup

### DIFF
--- a/swift_setup.py
+++ b/swift_setup.py
@@ -207,8 +207,9 @@ def get_ic_metadata(args):
         data['m_pt1'] = f['PartType1']['Masses'][0] / data['HubbleParam']
         print(f"Read PT1 mass as {data['m_pt1']}")
 
-        data['m_gas'] = f['PartType0']['Masses'][0] / data['HubbleParam']
-        print(f"Read gas (PT0) mass as {data['m_gas']}")
+        if data['is_hydro']:
+            data['m_gas'] = f['PartType0']['Masses'][0] / data['HubbleParam']
+            print(f"Read gas (PT0) mass as {data['m_gas']}")
 
         data['is_zoom'] = h.attrs['NumPart_Total'][2] > 0
 

--- a/swift_setup.py
+++ b/swift_setup.py
@@ -207,8 +207,8 @@ def get_ic_metadata(args):
         data['m_pt1'] = f['PartType1']['Masses'][0] / data['HubbleParam']
         print(f"Read PT1 mass as {data['m_pt1']}")
 
-	data['m_pt0'] = f['PartType0']['Masses'][0] / data['HubbleParam']
-	print(f"Read gas (PT0) mass as {data['m_gas']}"
+        data['m_pt0'] = f['PartType0']['Masses'][0] / data['HubbleParam']
+        print(f"Read gas (PT0) mass as {data['m_gas']}"
 
         data['is_zoom'] = h.attrs['NumPart_Total'][2] > 0
 

--- a/swift_setup.py
+++ b/swift_setup.py
@@ -350,6 +350,7 @@ def generate_param_file(data, args):
     # If we have gas in the ICs, need to adjust softenings
     if data['ics_have_gas']:
         m_gas = float(data['m_gas'])
+        data['m_dm'] = data['m_pt1']
         m_av = data['m_gas'] * data['num_gas'] + data['m_dm'] * data['num_dm']
         m_av /= (data['num_gas'] + data['num_dm'])
         f_dm = float(np.cbrt(data['m_dm'] / m_av))

--- a/swift_setup.py
+++ b/swift_setup.py
@@ -207,8 +207,8 @@ def get_ic_metadata(args):
         data['m_pt1'] = f['PartType1']['Masses'][0] / data['HubbleParam']
         print(f"Read PT1 mass as {data['m_pt1']}")
 
-        data['m_pt0'] = f['PartType0']['Masses'][0] / data['HubbleParam']
-        print(f"Read gas (PT0) mass as {data['m_gas']}"
+        data['m_gas'] = f['PartType0']['Masses'][0] / data['HubbleParam']
+        print(f"Read gas (PT0) mass as {data['m_gas']}")
 
         data['is_zoom'] = h.attrs['NumPart_Total'][2] > 0
 

--- a/swift_setup.py
+++ b/swift_setup.py
@@ -207,6 +207,9 @@ def get_ic_metadata(args):
         data['m_pt1'] = f['PartType1']['Masses'][0] / data['HubbleParam']
         print(f"Read PT1 mass as {data['m_pt1']}")
 
+	data['m_pt0'] = f['PartType0']['Masses'][0] / data['HubbleParam']
+	print(f"Read gas (PT0) mass as {data['m_gas']}"
+
         data['is_zoom'] = h.attrs['NumPart_Total'][2] > 0
 
     set_default(data, 'dm_to_baryon_mass_ratio',


### PR DESCRIPTION
In `swift_setup.py` there was an attempt to use a gas mass that was never set. This is now read analogous to the PartType1 mass. There were also 2 names used for the PartType1 mass, patched this so that it works but might want to just use one name consistently.