### PR TITLE
Zero out HighWord in swift-format file.

### DIFF
--- a/convert_ics_for_swift.py
+++ b/convert_ics_for_swift.py
@@ -81,7 +81,6 @@ class SwiftICs:
                     "MassTable",
                     "NumFilesPerSnapshot",
                     "NumPart_Total",
-                    "NumPart_Total_HighWord",
                     "Time",
                     "HubbleParam",
                 ]:
@@ -252,6 +251,7 @@ class SwiftICs:
             self.header["NumFilesPerSnapshot"] = 1
             self.header["NumPart_ThisFile"] = self.num_parts
             self.header["NumPart_Total"] = self.num_parts
+            self.header["NumPart_Total_HighWord"] = [0 for _ in self.num_parts]
 
             h = f.create_group("Header")
             for key in self.header:

--- a/convert_ics_for_swift.py
+++ b/convert_ics_for_swift.py
@@ -247,12 +247,12 @@ class SwiftICs:
             print(f" Expect {self.num_parts[1]} DM type 1 particles")
             print(f" and {self.num_parts[0]} gas (type 0) particles.")
 
-        with h5.File(f"{self.out_file}.incomplete", "w") as f:
-            self.header["NumFilesPerSnapshot"] = 1
-            self.header["NumPart_ThisFile"] = self.num_parts
-            self.header["NumPart_Total"] = self.num_parts
-            self.header["NumPart_Total_HighWord"] = [0 for _ in self.num_parts]
+        self.header["NumFilesPerSnapshot"] = 1
+        self.header["NumPart_ThisFile"] = self.num_parts
+        self.header["NumPart_Total"] = [np % 2**32 for np in self.num_parts]
+        self.header["NumPart_Total_HighWord"] = [np // 2**32 for np in self.num_parts]
 
+        with h5.File(f"{self.out_file}.incomplete", "w") as f:
             h = f.create_group("Header")
             for key in self.header:
                 h.attrs[key] = self.header[key]


### PR DESCRIPTION
I'd added logic to write the total particle number directly in the swift-format ICs, but forgot to explicitly zero out the corresponding HighWord array in the header. Swift seems to ignore the HighWord part, but fixed this little bug anyway.